### PR TITLE
Re-parent from pom-fiji to pom-trakem2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
 
 	<parent>
 		<groupId>sc.fiji</groupId>
-		<artifactId>pom-fiji</artifactId>
-		<version>2.0.0-beta-0</version>
+		<artifactId>pom-trakem2</artifactId>
+		<version>1.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
The Fiji projects saw a recent push to clean up the project
configurations, in particular to provide Reproducible Builds. In this
light, the TrakEM2-related projects should reuse pom-trakem2 as Bill of
Materials.

For further rationale, see http://fiji.sc/Reproducible_builds and
http://fiji.sc/Bill_of_Materials, respectively.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
