### PR TITLE
Update to point to the new package location of DM3_Reader

### DIFF
--- a/src/main/java/register_virtual_stack/Register_Virtual_Stack_MT.java
+++ b/src/main/java/register_virtual_stack/Register_Virtual_Stack_MT.java
@@ -21,7 +21,7 @@ import ij.plugin.PlugIn;
 import ij.process.ByteProcessor;
 import ij.process.ImageProcessor;
 
-import io.DM3_Reader;
+import sc.fiji.io.DM3_Reader;
 
 import java.awt.Color;
 import java.awt.FileDialog;


### PR DESCRIPTION
Allows Register Virtual Stack Slices to work with .dm3 extension files again (offending spec change is at fiji/IO@9fb67a856742c57814650133715554bdef68e43a)